### PR TITLE
Custom player UI

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,23 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+    </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
       <arrangement>
         <rules>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -19,6 +19,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation "androidx.paging:paging-runtime:$paging_version"
 
     // Coil
-    implementation 'io.coil-kt:coil:0.11.0'
+    implementation 'io.coil-kt:coil:0.12.0'
 
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/app/src/main/java/com/coopra/nebulus/FeedTracksBoundaryCallback.kt
+++ b/app/src/main/java/com/coopra/nebulus/FeedTracksBoundaryCallback.kt
@@ -104,7 +104,7 @@ class FeedTracksBoundaryCallback(
 
     private suspend fun getWaveform(waveformUrl: String): IntArray {
         val request = Request.Builder()
-                .url(waveformUrl)
+                .url(waveformUrl.replace(".png", ".json"))
                 .build()
 
         return withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
+++ b/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
@@ -14,6 +14,7 @@ class WaveformPlayer : View {
     private val ringStrokeWidth =
             TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, resources.displayMetrics)
     private val ringPaint = Paint()
+    private val outerOval = RectF()
 
     constructor(context: Context?) : super(context) {
         init()
@@ -41,7 +42,7 @@ class WaveformPlayer : View {
 
         val diameter = min(width, height)
         val padding = ringStrokeWidth / 2
-        val outerOval = RectF(padding, padding, diameter - padding, diameter - padding)
+        outerOval.set(padding, padding, diameter - padding, diameter - padding)
         canvas?.drawArc(outerOval, 0f, 360f, false, ringPaint)
     }
 }

--- a/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
+++ b/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
@@ -1,20 +1,23 @@
 package com.coopra.nebulus.controls
 
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.RectF
+import android.graphics.*
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import kotlin.math.min
 
 class WaveformPlayer : View {
     private val ringStrokeWidth =
             TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, resources.displayMetrics)
-    private val ringPaint = Paint()
+    private val ringPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val artworkPaint = Paint(Paint.ANTI_ALIAS_FLAG)
     private val outerOval = RectF()
+    private var waveformData: IntArray? = null
+    private val artworkRect = RectF()
 
     constructor(context: Context?) : super(context) {
         init()
@@ -30,10 +33,25 @@ class WaveformPlayer : View {
         init()
     }
 
+    fun setWaveformData(waveformData: IntArray) {
+        this.waveformData = waveformData
+    }
+
+    fun setArtworkDrawable(artwork: Drawable) {
+        if (width > 0 && height > 0) {
+            val diameter = min(width, height)
+            artworkPaint.shader =
+                    BitmapShader(artwork.toBitmap(diameter,
+                            diameter),
+                            Shader.TileMode.MIRROR,
+                            Shader.TileMode.MIRROR)
+            invalidate()
+        }
+    }
+
     private fun init() {
         ringPaint.color = ContextCompat.getColor(context, android.R.color.holo_red_light)
         ringPaint.strokeWidth = ringStrokeWidth
-        ringPaint.isAntiAlias = true
         ringPaint.style = Paint.Style.STROKE
     }
 
@@ -44,5 +62,16 @@ class WaveformPlayer : View {
         val padding = ringStrokeWidth / 2
         outerOval.set(padding, padding, diameter - padding, diameter - padding)
         canvas?.drawArc(outerOval, 0f, 360f, false, ringPaint)
+
+        if (artworkPaint.shader != null) {
+            artworkRect.set(ringStrokeWidth,
+                    ringStrokeWidth,
+                    diameter - ringStrokeWidth,
+                    diameter - ringStrokeWidth)
+            canvas?.drawRoundRect(artworkRect,
+                    artworkRect.width() / 2,
+                    artworkRect.height() / 2,
+                    artworkPaint)
+        }
     }
 }

--- a/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
+++ b/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
@@ -15,8 +15,10 @@ class WaveformPlayer : View {
             TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, resources.displayMetrics)
     private val ringPaint = Paint(Paint.ANTI_ALIAS_FLAG)
     private val artworkPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val waveformPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+
     private val outerOval = RectF()
-    private var waveformData: IntArray? = null
+    private var waveformData = mutableListOf<Int>()
     private val artworkRect = RectF()
 
     constructor(context: Context?) : super(context) {
@@ -34,7 +36,17 @@ class WaveformPlayer : View {
     }
 
     fun setWaveformData(waveformData: IntArray) {
-        this.waveformData = waveformData
+        var index = 0
+        for (dataPoint in waveformData) {
+            if (index == 0) {
+                this.waveformData.add(dataPoint)
+            }
+
+            index++
+            if (index == 25) {
+                index = 0
+            }
+        }
     }
 
     fun setArtworkDrawable(artwork: Drawable) {
@@ -53,12 +65,37 @@ class WaveformPlayer : View {
         ringPaint.color = ContextCompat.getColor(context, android.R.color.holo_red_light)
         ringPaint.strokeWidth = ringStrokeWidth
         ringPaint.style = Paint.Style.STROKE
+
+        waveformPaint.color = ContextCompat.getColor(context, android.R.color.darker_gray)
+        waveformPaint.strokeWidth = ringStrokeWidth
+        waveformPaint.style = Paint.Style.STROKE
     }
 
     override fun onDraw(canvas: Canvas?) {
         super.onDraw(canvas)
 
-        val diameter = min(width, height)
+        val diameter: Int
+        if (waveformData.isNotEmpty()) {
+            diameter = min(width, height) - (waveformData.max()!! * 2)
+
+            canvas?.save()
+            for (waveformBar in waveformData) {
+                canvas?.drawLine(
+                        width / 2f,
+                        (height / 2f) - (diameter / 2f),
+                        width / 2f,
+                        ((height / 2f) - (diameter / 2f)) - waveformBar,
+                        waveformPaint
+                )
+
+                canvas?.rotate(25f, width / 2f, height / 2f)
+            }
+
+            canvas?.restore()
+        } else {
+            diameter = min(width, height)
+        }
+
         val padding = ringStrokeWidth / 2
         outerOval.set(((width / 2) - (diameter / 2) + padding),
                 ((height / 2) - (diameter / 2) + padding),

--- a/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
+++ b/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
@@ -1,0 +1,47 @@
+package com.coopra.nebulus.controls
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.View
+import androidx.core.content.ContextCompat
+import kotlin.math.min
+
+class WaveformPlayer : View {
+    private val ringStrokeWidth =
+            TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, resources.displayMetrics)
+    private val ringPaint = Paint()
+
+    constructor(context: Context?) : super(context) {
+        init()
+    }
+
+    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {
+        init()
+    }
+
+    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context,
+            attrs,
+            defStyleAttr) {
+        init()
+    }
+
+    private fun init() {
+        ringPaint.color = ContextCompat.getColor(context, android.R.color.holo_red_light)
+        ringPaint.strokeWidth = ringStrokeWidth
+        ringPaint.isAntiAlias = true
+        ringPaint.style = Paint.Style.STROKE
+    }
+
+    override fun onDraw(canvas: Canvas?) {
+        super.onDraw(canvas)
+
+        val diameter = min(width, height)
+        val padding = ringStrokeWidth / 2
+        val outerOval = RectF(padding, padding, diameter - padding, diameter - padding)
+        canvas?.drawArc(outerOval, 0f, 360f, false, ringPaint)
+    }
+}

--- a/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
+++ b/app/src/main/java/com/coopra/nebulus/controls/WaveformPlayer.kt
@@ -60,14 +60,17 @@ class WaveformPlayer : View {
 
         val diameter = min(width, height)
         val padding = ringStrokeWidth / 2
-        outerOval.set(padding, padding, diameter - padding, diameter - padding)
+        outerOval.set(((width / 2) - (diameter / 2) + padding),
+                ((height / 2) - (diameter / 2) + padding),
+                ((width / 2) + (diameter / 2) - padding),
+                ((height / 2) + (diameter / 2) - padding))
         canvas?.drawArc(outerOval, 0f, 360f, false, ringPaint)
 
         if (artworkPaint.shader != null) {
-            artworkRect.set(ringStrokeWidth,
-                    ringStrokeWidth,
-                    diameter - ringStrokeWidth,
-                    diameter - ringStrokeWidth)
+            artworkRect.set(outerOval.left + padding,
+                    outerOval.top + padding,
+                    outerOval.right - padding,
+                    outerOval.bottom - padding)
             canvas?.drawRoundRect(artworkRect,
                     artworkRect.width() / 2,
                     artworkRect.height() / 2,

--- a/app/src/main/java/com/coopra/nebulus/view_models/FeedViewModel.kt
+++ b/app/src/main/java/com/coopra/nebulus/view_models/FeedViewModel.kt
@@ -7,13 +7,19 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagedList
 import com.coopra.data.DashboardActivityEnvelope
+import com.coopra.data.Waveform
 import com.coopra.database.entities.Track
 import com.coopra.database.entities.User
 import com.coopra.nebulus.TokenHandler
 import com.coopra.nebulus.TrackRepository
 import com.coopra.nebulus.enums.NetworkStates
 import com.coopra.service.service_implementations.ActivitiesService
+import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -24,6 +30,8 @@ class FeedViewModel(application: Application) : AndroidViewModel(application) {
     private val networkState = MutableLiveData<NetworkStates>()
     private val activitiesService = ActivitiesService()
     private val tokenHandler = TokenHandler()
+    private val gson = Gson()
+    private val client = OkHttpClient()
 
     init {
         repository = TrackRepository(application, networkState)
@@ -41,16 +49,18 @@ class FeedViewModel(application: Application) : AndroidViewModel(application) {
     fun refreshFeed() {
         networkState.value = NetworkStates.LOADING
 
-        activitiesService.getFeedTracks(tokenHandler.getToken(getApplication())!!, object : Callback<DashboardActivityEnvelope> {
-            override fun onResponse(call: Call<DashboardActivityEnvelope>, response: Response<DashboardActivityEnvelope>) {
-                handleSuccessfulNetworkCall(response)
-                networkState.postValue(NetworkStates.NORMAL)
-            }
+        activitiesService.getFeedTracks(tokenHandler.getToken(getApplication())!!,
+                object : Callback<DashboardActivityEnvelope> {
+                    override fun onResponse(
+                            call: Call<DashboardActivityEnvelope>,
+                            response: Response<DashboardActivityEnvelope>) {
+                        handleSuccessfulNetworkCall(response)
+                    }
 
-            override fun onFailure(call: Call<DashboardActivityEnvelope>, t: Throwable) {
-                networkState.postValue(NetworkStates.NORMAL)
-            }
-        })
+                    override fun onFailure(call: Call<DashboardActivityEnvelope>, t: Throwable) {
+                        networkState.postValue(NetworkStates.NORMAL)
+                    }
+                })
     }
 
     private fun handleSuccessfulNetworkCall(response: Response<DashboardActivityEnvelope>) {
@@ -58,16 +68,37 @@ class FeedViewModel(application: Application) : AndroidViewModel(application) {
         val tracks = mutableListOf<Track>()
         val users = mutableListOf<User>()
 
-        for (activity in activityEnvelope.collection) {
-            val origin = activity.origin ?: continue
-            tracks.add(Track(origin, activityEnvelope.next_href, activity.created_at))
-            users.add(User(origin.user))
-        }
+        viewModelScope.launch {
+            for (activity in activityEnvelope.collection) {
+                val origin = activity.origin ?: continue
+                if (origin.kind != "track" || origin.waveform_url.isNullOrEmpty()) {
+                    continue
+                }
 
-        if (tracks.size > 0) {
-            viewModelScope.launch {
+                tracks.add(Track(origin,
+                        activityEnvelope.next_href,
+                        activity.created_at,
+                        getWaveform(origin.waveform_url!!)))
+                users.add(User(origin.user))
+            }
+
+            if (tracks.size > 0) {
                 repository.insertAll(TrackRepository.TrackParameters(tracks, users))
             }
+
+            networkState.postValue(NetworkStates.NORMAL)
+        }
+    }
+
+    private suspend fun getWaveform(waveformUrl: String): IntArray {
+        val request = Request.Builder()
+                .url(waveformUrl)
+                .build()
+
+        return withContext(Dispatchers.IO) {
+            val response = client.newCall(request).execute()
+            val waveform = gson.fromJson(response.body()?.charStream(), Waveform::class.java)
+            waveform.samples
         }
     }
 }

--- a/app/src/main/java/com/coopra/nebulus/view_models/FeedViewModel.kt
+++ b/app/src/main/java/com/coopra/nebulus/view_models/FeedViewModel.kt
@@ -92,7 +92,7 @@ class FeedViewModel(application: Application) : AndroidViewModel(application) {
 
     private suspend fun getWaveform(waveformUrl: String): IntArray {
         val request = Request.Builder()
-                .url(waveformUrl)
+                .url(waveformUrl.replace(".png", ".json"))
                 .build()
 
         return withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/coopra/nebulus/view_models/PlayerViewModel.kt
+++ b/app/src/main/java/com/coopra/nebulus/view_models/PlayerViewModel.kt
@@ -16,7 +16,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
     private val imageLoader = ImageLoader.Builder(application)
             .build()
 
-    private var activeTrack: Track? = null
+    var activeTrack: Track? = null
     val artwork: LiveData<Drawable>
         get() = _artwork
     private val _artwork = MutableLiveData<Drawable>()
@@ -29,9 +29,5 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
             val result = imageLoader.execute(request)
             _artwork.postValue(result.drawable)
         }
-    }
-
-    fun setActiveTrack(track: Track) {
-        activeTrack = track
     }
 }

--- a/app/src/main/java/com/coopra/nebulus/view_models/PlayerViewModel.kt
+++ b/app/src/main/java/com/coopra/nebulus/view_models/PlayerViewModel.kt
@@ -1,0 +1,37 @@
+package com.coopra.nebulus.view_models
+
+import android.app.Application
+import android.graphics.drawable.Drawable
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import coil.ImageLoader
+import coil.request.ImageRequest
+import com.coopra.database.entities.Track
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class PlayerViewModel(application: Application) : AndroidViewModel(application) {
+    private val imageLoader = ImageLoader.Builder(application)
+            .build()
+
+    private var activeTrack: Track? = null
+    val artwork: LiveData<Drawable>
+        get() = _artwork
+    private val _artwork = MutableLiveData<Drawable>()
+
+    fun getArtwork() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val request = ImageRequest.Builder(getApplication() as Application)
+                    .data(activeTrack?.artworkUrl?.replace("large", "t500x500"))
+                    .build()
+            val result = imageLoader.execute(request)
+            _artwork.postValue(result.drawable)
+        }
+    }
+
+    fun setActiveTrack(track: Track) {
+        activeTrack = track
+    }
+}

--- a/app/src/main/java/com/coopra/nebulus/views/adapters/TrackListAdapter.kt
+++ b/app/src/main/java/com/coopra/nebulus/views/adapters/TrackListAdapter.kt
@@ -8,7 +8,7 @@ import android.widget.TextView
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import coil.api.load
+import coil.load
 import com.coopra.database.entities.Track
 import com.coopra.nebulus.R
 

--- a/app/src/main/java/com/coopra/nebulus/views/adapters/TrackListAdapter.kt
+++ b/app/src/main/java/com/coopra/nebulus/views/adapters/TrackListAdapter.kt
@@ -12,7 +12,7 @@ import coil.api.load
 import com.coopra.database.entities.Track
 import com.coopra.nebulus.R
 
-class TrackListAdapter : PagedListAdapter<Track, TrackListAdapter.TrackViewHolder>(
+class TrackListAdapter(private val selectionListener: SelectionListener) : PagedListAdapter<Track, TrackListAdapter.TrackViewHolder>(
         DIFF_CALLBACK) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrackViewHolder {
         val itemView = LayoutInflater.from(parent.context)
@@ -29,6 +29,7 @@ class TrackListAdapter : PagedListAdapter<Track, TrackListAdapter.TrackViewHolde
             holder.genreView.text =
                     holder.genreView.context.resources.getString(R.string.genre_tag, current.genre)
             holder.artworkView.load(current.artworkUrl?.replace("large", "t500x500"))
+            holder.itemView.setOnClickListener { selectionListener.onClick(current) }
         } else {
             // Covers the case of data not being ready yet
             holder.titleView.text = "No tracks"
@@ -54,5 +55,9 @@ class TrackListAdapter : PagedListAdapter<Track, TrackListAdapter.TrackViewHolde
             }
 
         }
+    }
+
+    interface SelectionListener {
+        fun onClick(track: Track)
     }
 }

--- a/app/src/main/java/com/coopra/nebulus/views/fragments/FeedFragment.kt
+++ b/app/src/main/java/com/coopra/nebulus/views/fragments/FeedFragment.kt
@@ -5,18 +5,23 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.coopra.database.entities.Track
+import com.coopra.nebulus.R
 import com.coopra.nebulus.databinding.FragmentFeedBinding
 import com.coopra.nebulus.enums.NetworkStates
 import com.coopra.nebulus.view_models.FeedViewModel
 import com.coopra.nebulus.views.adapters.TrackListAdapter
 
-class FeedFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
+class FeedFragment : Fragment(),
+        SwipeRefreshLayout.OnRefreshListener,
+        TrackListAdapter.SelectionListener {
     private var _binding: FragmentFeedBinding? = null
-    private val adapter = TrackListAdapter()
+    private val adapter = TrackListAdapter(this)
     private val viewModel: FeedViewModel by activityViewModels()
     // This property is only valid between onCreateView and onDestroyView
     private val binding get() = _binding!!
@@ -56,5 +61,13 @@ class FeedFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
     override fun onRefresh() {
         viewModel.refreshFeed()
+    }
+
+    override fun onClick(track: Track) {
+        parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, PlayerFragment())
+                .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+                .addToBackStack(null)
+                .commit()
     }
 }

--- a/app/src/main/java/com/coopra/nebulus/views/fragments/FeedFragment.kt
+++ b/app/src/main/java/com/coopra/nebulus/views/fragments/FeedFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -15,6 +16,7 @@ import com.coopra.nebulus.R
 import com.coopra.nebulus.databinding.FragmentFeedBinding
 import com.coopra.nebulus.enums.NetworkStates
 import com.coopra.nebulus.view_models.FeedViewModel
+import com.coopra.nebulus.view_models.PlayerViewModel
 import com.coopra.nebulus.views.adapters.TrackListAdapter
 
 class FeedFragment : Fragment(),
@@ -22,7 +24,8 @@ class FeedFragment : Fragment(),
         TrackListAdapter.SelectionListener {
     private var _binding: FragmentFeedBinding? = null
     private val adapter = TrackListAdapter(this)
-    private val viewModel: FeedViewModel by activityViewModels()
+    private val viewModel: FeedViewModel by viewModels()
+    private val playerViewModel: PlayerViewModel by activityViewModels()
     // This property is only valid between onCreateView and onDestroyView
     private val binding get() = _binding!!
 
@@ -64,6 +67,7 @@ class FeedFragment : Fragment(),
     }
 
     override fun onClick(track: Track) {
+        playerViewModel.setActiveTrack(track)
         parentFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, PlayerFragment())
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)

--- a/app/src/main/java/com/coopra/nebulus/views/fragments/FeedFragment.kt
+++ b/app/src/main/java/com/coopra/nebulus/views/fragments/FeedFragment.kt
@@ -67,7 +67,7 @@ class FeedFragment : Fragment(),
     }
 
     override fun onClick(track: Track) {
-        playerViewModel.setActiveTrack(track)
+        playerViewModel.activeTrack = track
         parentFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, PlayerFragment())
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)

--- a/app/src/main/java/com/coopra/nebulus/views/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/coopra/nebulus/views/fragments/PlayerFragment.kt
@@ -5,10 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Observer
 import com.coopra.nebulus.databinding.FragmentPlayerBinding
+import com.coopra.nebulus.view_models.PlayerViewModel
 
 class PlayerFragment : Fragment() {
     private var _binding: FragmentPlayerBinding? = null
+    private val viewModel: PlayerViewModel by activityViewModels()
     // This property is only valid between onCreateView and onDestroyView
     private val binding get() = _binding!!
 
@@ -23,5 +27,15 @@ class PlayerFragment : Fragment() {
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel.artwork.observe(viewLifecycleOwner, Observer {
+            binding.waveformPlayer.setArtworkDrawable(it)
+        })
+
+        viewModel.getArtwork()
     }
 }

--- a/app/src/main/java/com/coopra/nebulus/views/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/coopra/nebulus/views/fragments/PlayerFragment.kt
@@ -1,0 +1,27 @@
+package com.coopra.nebulus.views.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.coopra.nebulus.databinding.FragmentPlayerBinding
+
+class PlayerFragment : Fragment() {
+    private var _binding: FragmentPlayerBinding? = null
+    // This property is only valid between onCreateView and onDestroyView
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?): View? {
+        _binding = FragmentPlayerBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/com/coopra/nebulus/views/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/coopra/nebulus/views/fragments/PlayerFragment.kt
@@ -37,5 +37,9 @@ class PlayerFragment : Fragment() {
         })
 
         viewModel.getArtwork()
+
+        if (viewModel.activeTrack != null) {
+            binding.waveformPlayer.setWaveformData(viewModel.activeTrack!!.waveform)
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -14,6 +14,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
     <com.coopra.nebulus.controls.WaveformPlayer
+            android:id="@+id/waveform_player"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="24dp"

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="This is the player!"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -13,4 +13,14 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+    <com.coopra.nebulus.controls.WaveformPlayer
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginEnd="24dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -4,15 +4,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="This is the player!"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
     <com.coopra.nebulus.controls.WaveformPlayer
             android:id="@+id/waveform_player"
             android:layout_width="0dp"

--- a/data/src/main/java/com/coopra/data/DashboardActivity.kt
+++ b/data/src/main/java/com/coopra/data/DashboardActivity.kt
@@ -1,7 +1,7 @@
 package com.coopra.data
 
 data class DashboardActivity(
-        val origin: Track?,
+        val origin: Origin?,
         val created_at: String,
         val type: String
 )

--- a/data/src/main/java/com/coopra/data/Origin.kt
+++ b/data/src/main/java/com/coopra/data/Origin.kt
@@ -3,9 +3,9 @@ package com.coopra.data
 /**
  * A SoundCloud track
  */
-data class Track(
+data class Origin(
         /**
-         * Track ID
+         * Origin ID
          */
         val id: Int,
 
@@ -62,5 +62,15 @@ data class Track(
         /**
          * Track likes count
          */
-        val likes_count: Int
+        val likes_count: Int,
+
+        /**
+         * Link to get JSON representation of waveform
+         */
+        val waveform_url: String?,
+
+        /**
+         * Type of origin, e.g. track or playlist
+         */
+        val kind: String
 )

--- a/data/src/main/java/com/coopra/data/Waveform.kt
+++ b/data/src/main/java/com/coopra/data/Waveform.kt
@@ -1,0 +1,7 @@
+package com.coopra.data
+
+data class Waveform(
+        val width: Int,
+        val height: Int,
+        val samples: IntArray
+)

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     // Paging components
     implementation "androidx.paging:paging-runtime:$paging_version"
 
-    implementation 'com.google.code.gson:gson:2.8.6'
+    api 'com.google.code.gson:gson:2.8.6'
 
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/database/src/main/java/com/coopra/database/Converters.kt
+++ b/database/src/main/java/com/coopra/database/Converters.kt
@@ -16,4 +16,16 @@ class Converters {
         val gson = Gson()
         return gson.fromJson(userJson, User::class.java)
     }
+
+    @TypeConverter
+    fun fromWaveform(waveform: IntArray): String {
+        val gson = Gson()
+        return gson.toJson(waveform)
+    }
+
+    @TypeConverter
+    fun toWaveform(waveformJson: String): IntArray {
+        val gson = Gson()
+        return gson.fromJson(waveformJson, IntArray::class.java)
+    }
 }

--- a/database/src/main/java/com/coopra/database/entities/Track.kt
+++ b/database/src/main/java/com/coopra/database/entities/Track.kt
@@ -4,7 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
-import com.coopra.data.Track
+import com.coopra.data.Origin
 
 @Entity(tableName = "track_table",
         foreignKeys = [ForeignKey(entity = User::class,
@@ -24,22 +24,26 @@ data class Track(
         @ColumnInfo(name = "user_favorite") val userFavorite: Boolean,
         @ColumnInfo(name = "likes_count") val likesCount: Int,
         @ColumnInfo(name = "next_href") val nextToken: String,
-        @ColumnInfo(name = "activity_created_at") val activityCreatedAt: String
+        @ColumnInfo(name = "activity_created_at") val activityCreatedAt: String,
+        @ColumnInfo(name = "waveform") val waveform: IntArray
 ) {
-    constructor(serverTrack: Track,
-                nextToken: String,
-                activityCreatedAt: String) : this(serverTrack.id,
-            serverTrack.created_at,
-            serverTrack.user_id,
-            User(serverTrack.user),
-            serverTrack.title,
-            serverTrack.artwork_url,
-            serverTrack.duration,
-            serverTrack.genre,
-            serverTrack.stream_url,
-            serverTrack.playback_count,
-            serverTrack.user_favorite,
-            serverTrack.likes_count,
+    constructor(
+            serverOrigin: Origin,
+            nextToken: String,
+            activityCreatedAt: String,
+            waveform: IntArray) : this(serverOrigin.id,
+            serverOrigin.created_at,
+            serverOrigin.user_id,
+            User(serverOrigin.user),
+            serverOrigin.title,
+            serverOrigin.artwork_url,
+            serverOrigin.duration,
+            serverOrigin.genre,
+            serverOrigin.stream_url,
+            serverOrigin.playback_count,
+            serverOrigin.user_favorite,
+            serverOrigin.likes_count,
             nextToken,
-            activityCreatedAt)
+            activityCreatedAt,
+            waveform)
 }

--- a/service/src/main/java/com/coopra/service/interfaces/TracksInterface.kt
+++ b/service/src/main/java/com/coopra/service/interfaces/TracksInterface.kt
@@ -1,11 +1,11 @@
 package com.coopra.service.interfaces
 
-import com.coopra.data.Track
+import com.coopra.data.Origin
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface TracksInterface {
     @GET("tracks")
-    fun getRandomTracks(@Query("client_id") clientId: String): Call<List<Track>>
+    fun getRandomTracks(@Query("client_id") clientId: String): Call<List<Origin>>
 }

--- a/service/src/main/java/com/coopra/service/service_implementations/TracksService.kt
+++ b/service/src/main/java/com/coopra/service/service_implementations/TracksService.kt
@@ -1,6 +1,6 @@
 package com.coopra.service.service_implementations
 
-import com.coopra.data.Track
+import com.coopra.data.Origin
 import com.coopra.service.BuildConfig
 import com.coopra.service.RetrofitHelper
 import com.coopra.service.interfaces.TracksInterface
@@ -9,7 +9,7 @@ import retrofit2.Callback
 class TracksService {
     private val retrofitHelper = RetrofitHelper()
 
-    fun getRandomTracks(callback: Callback<List<Track>>) {
+    fun getRandomTracks(callback: Callback<List<Origin>>) {
         val service = retrofitHelper.createRetrofit().create(TracksInterface::class.java)
         val call = service.getRandomTracks(BuildConfig.CLIENT_ID)
         call.enqueue(callback)


### PR DESCRIPTION
Achieves the following:

- UI for custom player control that includes artwork and waveform
- Added network call to retrieve the waveform information of a track which is stored in its database entry
- Added a ViewModel for the player page which right now is used to retrieve the artwork of a track using Coil, to pass it to the custom player control
- Added ability to select a track and be taken to the player page
- Small changes to data model objects to match changes in SoundCloud's API