### PR TITLE
Use Retrofit's suspend capabilities

### DIFF
--- a/app/src/main/java/com/coopra/nebulus/FeedHelper.kt
+++ b/app/src/main/java/com/coopra/nebulus/FeedHelper.kt
@@ -1,0 +1,31 @@
+package com.coopra.nebulus
+
+import com.coopra.data.DashboardActivityEnvelope
+import com.coopra.database.entities.Track
+import com.coopra.database.entities.User
+
+class FeedHelper(private val repository: TrackRepository) {
+    private val waveformHelper = WaveformHelper()
+
+    suspend fun processActivityEnvelope(activityEnvelope: DashboardActivityEnvelope) {
+        val tracks = mutableListOf<Track>()
+        val users = mutableListOf<User>()
+
+        for (activity in activityEnvelope.collection) {
+            val origin = activity.origin ?: continue
+            if (origin.kind != "track" || origin.waveform_url.isNullOrEmpty()) {
+                continue
+            }
+
+            tracks.add(Track(origin,
+                    activityEnvelope.next_href,
+                    activity.created_at,
+                    waveformHelper.getWaveform(origin.waveform_url!!)))
+            users.add(User(origin.user))
+        }
+
+        if (tracks.size > 0) {
+            repository.insertAll(TrackRepository.TrackParameters(tracks, users))
+        }
+    }
+}

--- a/app/src/main/java/com/coopra/nebulus/FeedTracksBoundaryCallback.kt
+++ b/app/src/main/java/com/coopra/nebulus/FeedTracksBoundaryCallback.kt
@@ -3,27 +3,20 @@ package com.coopra.nebulus
 import androidx.lifecycle.MutableLiveData
 import androidx.paging.PagedList
 import com.coopra.data.DashboardActivityEnvelope
-import com.coopra.data.Waveform
 import com.coopra.database.entities.Track
-import com.coopra.database.entities.User
 import com.coopra.nebulus.enums.NetworkStates
 import com.coopra.service.service_implementations.ActivitiesService
-import com.google.gson.Gson
-import kotlinx.coroutines.*
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 
 class FeedTracksBoundaryCallback(
-        private val repository: TrackRepository,
+        repository: TrackRepository,
         private val token: String,
         private val networkState: MutableLiveData<NetworkStates>) : PagedList.BoundaryCallback<Track>() {
     private val activitiesService = ActivitiesService()
     private var isLoading = false
-    private val gson = Gson()
-    private val client = OkHttpClient()
+    private val feedHelper = FeedHelper(repository)
 
     /**
      * Requests initial data from the network, replacing all content currently in the database.
@@ -36,18 +29,14 @@ class FeedTracksBoundaryCallback(
         isLoading = true
         networkState.postValue(NetworkStates.LOADING)
 
-        activitiesService.getFeedTracks(token, object : Callback<DashboardActivityEnvelope> {
-            override fun onResponse(
-                    call: Call<DashboardActivityEnvelope>,
-                    response: Response<DashboardActivityEnvelope>) {
-                handleSuccessfulNetworkCall(response)
-            }
-
-            override fun onFailure(call: Call<DashboardActivityEnvelope>, t: Throwable) {
+        MainScope().launch(Dispatchers.IO) {
+            try {
+                handleSuccessfulNetworkCall(activitiesService.getFeedTracks(token))
+            } catch (ex: Exception) {
                 isLoading = false
                 networkState.postValue(NetworkStates.NORMAL)
             }
-        })
+        }
     }
 
     override fun onItemAtEndLoaded(itemAtEnd: Track) {
@@ -58,59 +47,21 @@ class FeedTracksBoundaryCallback(
         isLoading = true
         networkState.postValue(NetworkStates.LOADING)
 
-        activitiesService.getNextTracks(token,
-                itemAtEnd.nextToken,
-                object : Callback<DashboardActivityEnvelope> {
-                    override fun onResponse(
-                            call: Call<DashboardActivityEnvelope>,
-                            response: Response<DashboardActivityEnvelope>) {
-                        handleSuccessfulNetworkCall(response)
-                    }
-
-                    override fun onFailure(call: Call<DashboardActivityEnvelope>, t: Throwable) {
-                        isLoading = false
-                        networkState.postValue(NetworkStates.NORMAL)
-                    }
-                })
-    }
-
-    private fun handleSuccessfulNetworkCall(response: Response<DashboardActivityEnvelope>) {
-        val activityEnvelope = response.body() ?: return
-        val tracks = mutableListOf<Track>()
-        val users = mutableListOf<User>()
-
-        MainScope().launch {
-            for (activity in activityEnvelope.collection) {
-                val origin = activity.origin ?: continue
-                if (origin.kind != "track" || origin.waveform_url.isNullOrEmpty()) {
-                    continue
-                }
-
-                tracks.add(Track(origin,
-                        activityEnvelope.next_href,
-                        activity.created_at,
-                        getWaveform(origin.waveform_url!!)))
-                users.add(User(origin.user))
+        MainScope().launch(Dispatchers.IO) {
+            try {
+                handleSuccessfulNetworkCall(activitiesService.getNextTracks(token,
+                        itemAtEnd.nextToken))
+            } catch (ex: Exception) {
+                isLoading = false
+                networkState.postValue(NetworkStates.NORMAL)
             }
-
-            if (tracks.size > 0) {
-                repository.insertAll(TrackRepository.TrackParameters(tracks, users))
-            }
-
-            isLoading = false
-            networkState.postValue(NetworkStates.NORMAL)
         }
     }
 
-    private suspend fun getWaveform(waveformUrl: String): IntArray {
-        val request = Request.Builder()
-                .url(waveformUrl.replace(".png", ".json"))
-                .build()
+    private suspend fun handleSuccessfulNetworkCall(activityEnvelope: DashboardActivityEnvelope) {
+        feedHelper.processActivityEnvelope(activityEnvelope)
 
-        return withContext(Dispatchers.IO) {
-            val response = client.newCall(request).execute()
-            val waveform = gson.fromJson(response.body()?.charStream(), Waveform::class.java)
-            waveform.samples
-        }
+        isLoading = false
+        networkState.postValue(NetworkStates.NORMAL)
     }
 }

--- a/app/src/main/java/com/coopra/nebulus/WaveformHelper.kt
+++ b/app/src/main/java/com/coopra/nebulus/WaveformHelper.kt
@@ -1,0 +1,33 @@
+package com.coopra.nebulus
+
+import com.coopra.data.Waveform
+import com.google.gson.Gson
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.*
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class WaveformHelper {
+    private val gson = Gson()
+    private val client = OkHttpClient()
+
+    suspend fun getWaveform(waveformUrl: String): IntArray =
+            suspendCancellableCoroutine { continuation ->
+                val request = Request.Builder()
+                        .url(waveformUrl.replace(".png", ".json"))
+                        .build()
+
+                client.newCall(request).enqueue(object : Callback {
+                    override fun onFailure(call: Call, e: IOException) {
+                        continuation.resumeWithException(e)
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        val waveform =
+                                gson.fromJson(response.body()?.charStream(), Waveform::class.java)
+                        continuation.resume(waveform.samples)
+                    }
+                })
+            }
+}

--- a/service/src/main/java/com/coopra/service/interfaces/ActivitiesInterface.kt
+++ b/service/src/main/java/com/coopra/service/interfaces/ActivitiesInterface.kt
@@ -1,15 +1,14 @@
 package com.coopra.service.interfaces
 
 import com.coopra.data.DashboardActivityEnvelope
-import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Query
 import retrofit2.http.Url
 
 interface ActivitiesInterface {
     @GET("me/activities?limit=50")
-    fun getFeedTracks(@Query("oauth_token") token: String): Call<DashboardActivityEnvelope>
+    suspend fun getFeedTracks(@Query("oauth_token") token: String): DashboardActivityEnvelope
 
     @GET
-    fun getNextTracks(@Url url: String, @Query("oauth_token") token: String): Call<DashboardActivityEnvelope>
+    suspend fun getNextTracks(@Url url: String, @Query("oauth_token") token: String): DashboardActivityEnvelope
 }

--- a/service/src/main/java/com/coopra/service/service_implementations/ActivitiesService.kt
+++ b/service/src/main/java/com/coopra/service/service_implementations/ActivitiesService.kt
@@ -6,14 +6,13 @@ import com.coopra.service.interfaces.ActivitiesInterface
 
 class ActivitiesService {
     private val retrofitHelper = RetrofitHelper()
+    private val service = retrofitHelper.createRetrofit().create(ActivitiesInterface::class.java)
 
     suspend fun getFeedTracks(token: String): DashboardActivityEnvelope {
-        val service = retrofitHelper.createRetrofit().create(ActivitiesInterface::class.java)
         return service.getFeedTracks(token)
     }
 
     suspend fun getNextTracks(token: String, url: String): DashboardActivityEnvelope {
-        val service = retrofitHelper.createRetrofit().create(ActivitiesInterface::class.java)
         return service.getNextTracks(url, token)
     }
 }

--- a/service/src/main/java/com/coopra/service/service_implementations/ActivitiesService.kt
+++ b/service/src/main/java/com/coopra/service/service_implementations/ActivitiesService.kt
@@ -3,20 +3,17 @@ package com.coopra.service.service_implementations
 import com.coopra.data.DashboardActivityEnvelope
 import com.coopra.service.RetrofitHelper
 import com.coopra.service.interfaces.ActivitiesInterface
-import retrofit2.Callback
 
 class ActivitiesService {
     private val retrofitHelper = RetrofitHelper()
 
-    fun getFeedTracks(token: String, callback: Callback<DashboardActivityEnvelope>) {
+    suspend fun getFeedTracks(token: String): DashboardActivityEnvelope {
         val service = retrofitHelper.createRetrofit().create(ActivitiesInterface::class.java)
-        val call = service.getFeedTracks(token)
-        call.enqueue(callback)
+        return service.getFeedTracks(token)
     }
 
-    fun getNextTracks(token: String, url: String, callback: Callback<DashboardActivityEnvelope>) {
+    suspend fun getNextTracks(token: String, url: String): DashboardActivityEnvelope {
         val service = retrofitHelper.createRetrofit().create(ActivitiesInterface::class.java)
-        val call = service.getNextTracks(url, token)
-        call.enqueue(callback)
+        return service.getNextTracks(url, token)
     }
 }


### PR DESCRIPTION
- Consolidate shared code between FeedViewModel and FeedTracksBoundaryCallback
- Don't create a new instance of the service every time we make a request